### PR TITLE
removed ANDROID_HOME environment variable definition

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-ANDROID_HOME=/Users/guilherme/Library/Android/sdk
-
 function vercomp () {
     if [[ $1 == $2 ]]
     then


### PR DESCRIPTION
this environment variable is defined by the bitrise stacks & shouldn't be hardcoded to one users directory

fixes issue #8